### PR TITLE
Remove unused `redirect` import and redundant call from sign-in page.

### DIFF
--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { authClient } from '@/lib/auth';
-import { redirect } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import LogoLong from '@/components/logo/LogoLong';
 
@@ -11,8 +10,6 @@ export default function SignUp() {
       provider: 'google',
       callbackURL: '/recruitment/dashboard',
     });
-
-    redirect('/dashboard');
   };
 
   return (


### PR DESCRIPTION
 ## Description
Fixes an issue where the "Sign in with Google" button was completely unresponsive on iPhone browsers (both Safari and Chrome).

### Root Cause
The unresponsiveness was caused by a race condition between `better-auth`'s external redirect to Google and Next.js's internal router, specifically triggered by a manual `redirect('/dashboard')` call immediately after initiating the sign-in.
When the login button was tapped:
1. `authClient.signIn.social()` fetched the Google OAuth URL and attempted to set `window.location.href` to redirect to Google.
2. Immediately after, `redirect('/dashboard')` was called, throwing a Next.js `NEXT_REDIRECT` exception.
3. Next.js caught this exception and started a client-side navigation to `/dashboard`.
4. Our middleware detected an unauthenticated state (since the Google login hadn't actually happened yet) and instantly redirected back to `/signin`.


### Why it worked on Desktop but not iOS:
Desktop browsers typically execute the `window.location.href` assignment fast enough to jump to Google before Next.js's internal navigation cycle and middleware redirect can complete. However, iOS WebKit aggressively aborts pending external location changes if
the page's DOM or internal History API starts changing—which happens the moment Next.js begins client-side navigation. As a result, the app was instantly routing to `/dashboard` and bouncing back to `/signin` so quickly that it appeared the button did absolutely
nothing.

### What Changed
- Removed the manual `redirect('/dashboard')` call from the `handleLogin` function in `src/app/signin/page.tsx`.
- Removed the unused `redirect` import from `next/navigation`.

### Why this works
By removing the manual Next.js redirect, `better-auth` is now allowed to correctly complete its authorization flow. It safely navigates to Google's servers without Next.js interrupting with a client-side route change. After successful authentication, the user is seamlessly redirected back using the `callbackURL: '/recruitment/dashboard'` that is already configured in the `signIn.social` call.